### PR TITLE
Explicit local executor definition

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -276,7 +276,7 @@ process merge_featureCounts {
  * Pipeline parameters to go into MultiQC report
  */
 process workflow_summary_mqc {
-
+    executor 'local'
     output:
     file 'workflow_summary_mqc.yaml' into workflow_summary_yaml
 


### PR DESCRIPTION
Explicitly set `local` executor for process `workflow_summary_mqc` to avoid 
unnecessary warning message when running deploying via cluster or cloud.